### PR TITLE
fix typo NCD -> NDC

### DIFF
--- a/python_etl/CMS_SynPuf_ETL_CDM_v5.py
+++ b/python_etl/CMS_SynPuf_ETL_CDM_v5.py
@@ -474,7 +474,7 @@ def build_maps():
 									status = "No self map from OMOP (HCPCS/CPT4) to OMOP (HCPCS/CPT4) or code invalid for " + concept_id
 									recs_skipped += 1
 								if( vocabulary_id == OMOP_CONSTANTS.NDC_VOCABULARY_ID):
-									status = "No map from OMOP (NCD) to OMOP (RxNorm) or code invalid for " + concept_id
+									status = "No map from OMOP (NDC) to OMOP (RxNorm) or code invalid for " + concept_id
 									recs_skipped += 1
 								source_code_concept_dict[vocabulary_id,concept_code] = [SourceCodeConcept(concept_code, concept_id, "0", destination_file)]
                         else:

--- a/python_etl/README.md
+++ b/python_etl/README.md
@@ -281,7 +281,7 @@ c) Only two ethnicity concepts (38003563, 38003564) are available.  38003563: Hi
 d) When a concept id has no mapping in the CONCEPT_RELATIONSHIP table:
 - If there is no mapping from OMOP (ICD9) to OMOP (SNOMED) for an ICD9 concept id, target_concept_id for such ICD9 concept id is populated with '0' .
 - If there is no self-mapping from OMOP (HCPCS/CPT4) to OMOP (HCPCS/CPT4) for an HCPCS/CPT4 concept id, target_concept_id for such HCPCS/CPT4 concept id is populated with '0' .
-- If there is no mapping from OMOP (NCD) to OMOP (RxNorm) for an NCD concept id, target_concept_id for such NCD concept id is populated with '0'.
+- If there is no mapping from OMOP (NDC) to OMOP (RxNorm) for an NDC concept id, target_concept_id for such NDC concept id is populated with '0'.
 
 e) The source data contains concepts that appear in the CONCEPT.csv file but do not have relationship mappings to target vocabularies. For these, we create records with concept_id 0 and include the source_concept_id in the record. Achilles Heel will give warnings about these concepts for the Condition, Observation, Procedure, and Drug tables as follows. If condition_concept_id or observation_concept_id or procedure_concept_id or drug_concept_id is '0' respectively:
 - WARNING: 400-Number of persons with at least one condition occurrence, by condition_concept_id; data with unmapped concepts

--- a/python_etl/constants.py
+++ b/python_etl/constants.py
@@ -63,7 +63,7 @@ class OMOP_CONSTANTS(object):
 
 # --------------------
 # Record layout for the CONCEPT_RELATIONSHIP.csv file
-# It is used to map: OMOP (NCD) -> OMOP (RXNORM)
+# It is used to map: OMOP (NDC) -> OMOP (RXNORM)
 # It is used to map: OMOP (ICD9) -> OMOP (SNOMED)
 # It is used to map: OMOP (HCPCS) -> OMOP (CPT4)
 # --------------------


### PR DESCRIPTION
Just proposing to fix some typos in the log messages for unmapped concept_ids